### PR TITLE
Fix flatten xml processor ignoring bean name.

### DIFF
--- a/cstudio-publishing-receiver/src/main/java/org/craftercms/cstudio/publishing/processor/SearchUpdateFlattenXmlProcessor.java
+++ b/cstudio-publishing-receiver/src/main/java/org/craftercms/cstudio/publishing/processor/SearchUpdateFlattenXmlProcessor.java
@@ -70,9 +70,4 @@ public class SearchUpdateFlattenXmlProcessor extends SearchUpdateProcessor {
         return super.createDocumentProcessorChain(chain);
     }
 
-    @Override
-    public String getName() {
-        return SearchUpdateFlattenXmlProcessor.class.getSimpleName();
-    }
-
 }


### PR DESCRIPTION
The getName() method is already provided by the base class.